### PR TITLE
chore: upgrade all components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine3.16@sha256:4e2a54594cfe7002a98c483c28f6f3a78e5c7f4010c355a8cf960292a3fdecfe
+FROM golang:1.22.3-alpine3.19@sha256:f1fe698725f6ed14eb944dc587591f134632ed47fc0732ec27c7642adbe90618
 
 # Add image labels
 LABEL org.opencontainers.image.title jx-goreleaser-image
@@ -13,16 +13,16 @@ RUN apk add --no-cache bash \
     build-base
 
 # Install syft
-RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.62.0 &&\
+RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.4.1 &&\
     chmod +x /usr/local/bin/syft &&\
     syft --version
 
 # Install cosign
-COPY --from=gcr.io/projectsigstore/cosign:v2.2.3@sha256:8fc9cad121611e8479f65f79f2e5bea58949e8a87ffac2a42cb99cf0ff079ba7 /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.2.4@sha256:bed7ba33a8610c1607c16dee696f62bad168814016126abb9da01e9fb7cb2167 /ko-app/cosign /usr/local/bin/cosign
 RUN cosign version
 
 # Install goreleaser
-RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v1.13.0/goreleaser_Linux_x86_64.tar.gz | tar xzv &&\
+RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v1.26.1/goreleaser_Linux_x86_64.tar.gz | tar xzv &&\
     rm -rf README.md completions manpages &&\
     mv goreleaser /usr/local/bin &&\
     goreleaser -v


### PR DESCRIPTION
We are starting to get in trouble when upgrading dependencies, since they might use features not present in go 1.19

related to jenkins-x/jx#8670