### PR TITLE
chore: upgrade to go 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | 
     syft --version
 
 # Install cosign
-COPY --from=ghcr.io/sigstore/cosign/cosign:v2.5.0@sha256:e82eb6d42ccb6bc048d8d9e5e598e4d5178e1af6c00e54e02c9b0569c5f3ec11 /ko-app/cosign /usr/local/bin/cosign
+COPY --from=ghcr.io/sigstore/cosign/cosign:v3.0.6@sha256:de9c65609e6bde17e6b48de485ee788407c9502fa08b8f4459f595b21f56cd00 /ko-app/cosign /usr/local/bin/cosign
 RUN cosign version
 
 # Install goreleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.22@sha256:be93003ee861b3b91b6ebcb22678524947e0cd786c2df3f32af520006b1e54f5
+FROM golang:1.26.3-alpine3.23@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
 
 # Add image labels
 LABEL org.opencontainers.image.title jx-goreleaser-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine3.22@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a
+FROM golang:1.26.3-alpine3.22@sha256:be93003ee861b3b91b6ebcb22678524947e0cd786c2df3f32af520006b1e54f5
 
 # Add image labels
 LABEL org.opencontainers.image.title jx-goreleaser-image
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash \
     build-base
 
 # Install syft
-RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.27.0 &&\
+RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.43.0 &&\
     chmod +x /usr/local/bin/syft &&\
     syft --version
 
@@ -22,7 +22,7 @@ COPY --from=ghcr.io/sigstore/cosign/cosign:v2.5.0@sha256:e82eb6d42ccb6bc048d8d9e
 RUN cosign version
 
 # Install goreleaser
-RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v2.10.2/goreleaser_Linux_x86_64.tar.gz | tar xzv &&\
+RUN curl -L https://github.com/goreleaser/goreleaser/releases/download/v2.15.3/goreleaser_Linux_x86_64.tar.gz | tar xzv &&\
     rm -rf README.md completions manpages &&\
     mv goreleaser /usr/local/bin &&\
     goreleaser -v


### PR DESCRIPTION
- upgrade golang alpine to golang:1.26.3-alpine3.23
- upgrade anchore/sfyt to 1.43.0
- upgrade goreleaser/goreleaser to 2.15.3
- upgrade sigstore/cosign to 3.0.6